### PR TITLE
Use version 1.79.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "version": "0.0.1",
   "engines": {
-    "vscode": "^1.80.0"
+    "vscode": "^1.79.0"
   },
   "categories": [
     "Other"

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,7 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ version: "insiders", extensionDevelopmentPath, extensionTestsPath });
+		await runTests({ version: "1.79.2", extensionDevelopmentPath, extensionTestsPath });
 	} catch (err) {
 		console.error('Failed to run tests', err);
 		process.exit(1);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,12 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ version: "1.79.2", extensionDevelopmentPath, extensionTestsPath, launchArgs: ["--disable-gpu"] });
+		await runTests({
+			version: "1.79.2",
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			launchArgs: ["--disable-gpu", "--disable-keytar"]
+		});
 	} catch (err) {
 		console.error('Failed to run tests', err);
 		process.exit(1);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,7 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ version: "1.79.2", extensionDevelopmentPath, extensionTestsPath });
+		await runTests({ version: "1.79.2", extensionDevelopmentPath, extensionTestsPath, launchArgs: ["--disable-gpu"] });
 	} catch (err) {
 		console.error('Failed to run tests', err);
 		process.exit(1);


### PR DESCRIPTION
Demo of "Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available."

The error appears on version 1.80, shown here: https://github.com/kolofordjango/encryption-not-available-demo/actions/runs/5575232697/jobs/10184874439#step:5:82

However, it does not happen on version 1.79.2, which can be seen in this PR.